### PR TITLE
Add Date support, remove ActiveSupport.

### DIFF
--- a/lib/time_iterator.rb
+++ b/lib/time_iterator.rb
@@ -1,13 +1,112 @@
-require "active_support"
-require "active_support/duration"
+require "date"
 
 # Time iteration.
 module TimeIterator
+  DATE_PARTS = [:years, :months, :weeks, :days].freeze
+  TIME_PARTS = [:hours, :minutes, :seconds].freeze
   class << self
     def iterate(start, by:, to: nil)
-      raise ArgumentError, "`by` must be an ActiveSupport::Duration" unless by.is_a?(ActiveSupport::Duration)
+      check_by(start, by: by)
 
       return to ? iterate_to(start, by: by, to: to) : iterate_endless(start, by: by)
+    end
+
+    private def check_by(start, by:)
+      raise ArgumentError, "`by` must be a Hash" unless by.is_a?(Hash)
+
+      return unless start.is_a?(Date)
+
+      invalid_parts = by.keys.intersection(TIME_PARTS)
+      raise ArgumentError, "Cannot iterate Date by #{invalid_parts}" unless invalid_parts.empty?
+    end
+
+    private def advance(start, by:)
+      start.is_a?(Time) ? advance_time(start, by: by) : advance_date(start, by: by)
+    end
+
+    # From rails/activesupport/lib/active_support/core_ext/time/calculations.rb
+    private def advance_time(time, by:) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      unless by[:weeks].nil?
+        by[:weeks], partial_weeks = by[:weeks].divmod(1)
+        by[:days] = by.fetch(:days, 0) + (7 * partial_weeks)
+      end
+
+      unless by[:days].nil?
+        by[:days], partial_days = by[:days].divmod(1)
+        by[:hours] = by.fetch(:hours, 0) + (24 * partial_days)
+      end
+
+      d = advance_date(time.to_date.gregorian, by: by)
+      time_advanced_by_date = change_time(time, by: { year: d.year, month: d.month, day: d.day})
+      seconds_to_advance =
+        by.fetch(:seconds, 0) +
+        (by.fetch(:minutes, 0) * 60) +
+        (by.fetch(:hours, 0) * 3600)
+
+      return time_advanced_by_date if seconds_to_advance.zero?
+
+      return time_advanced_by_date + seconds_to_advance
+    end
+
+    # From rails/activesupport/lib/active_support/core_ext/date/calculations.rb
+    private def advance_date(date, by:)
+      date >>= (by[:years] * 12) if by[:years]
+      date >>= by[:months] if by[:months]
+      date += (by[:weeks] * 7) if by[:weeks]
+      date += by[:days] if by[:days]
+
+      return date
+    end
+
+    # From rails/activesupport/lib/active_support/core_ext/time/calculations.rb
+    private def change_time(time, by:) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
+      new_year   = by.fetch(:year, time.year)
+      new_month  = by.fetch(:month, time.month)
+      new_day    = by.fetch(:day, time.day)
+      new_hour   = by.fetch(:hour, time.hour)
+      new_min    = by.fetch(:min, by[:hour] ? 0 : time.min)
+      new_sec    = by.fetch(:sec, by[:hour] || by[:min] ? 0 : time.sec)
+      new_offset = by.fetch(:offset, nil)
+
+      if (new_nsec = by[:nsec])
+        raise ArgumentError, "Can't change both :nsec and :usec at the same time: #{by.inspect}" if by[:usec]
+
+        new_usec = Rational(new_nsec, 1000)
+      else
+        new_usec = by.fetch(:usec, by[:hour] || by[:min] || by[:sec] ? 0 : Rational(time.nsec, 1000))
+      end
+
+      raise ArgumentError, "argument out of range" if new_usec >= 1_000_000
+
+      new_sec += Rational(new_usec, 1_000_000)
+
+      if new_offset
+        ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec, new_offset)
+      elsif time.utc?
+        ::Time.utc(new_year, new_month, new_day, new_hour, new_min, new_sec)
+      elsif time.zone.respond_to?(:utc_to_local)
+        new_time = ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec, zone)
+
+        # When there are two occurrences of a nominal time due to DST ending,
+        # `Time.new` chooses the first chronological occurrence (the one with a
+        # larger UTC offset). However, for `change`, we want to choose the
+        # occurrence that matches this time's UTC offset.
+        #
+        # If the new time's UTC offset is larger than this time's UTC offset, the
+        # new time might be a first chronological occurrence. So we add the offset
+        # difference to fast-forward the new time, and check if the result has the
+        # desired UTC offset (i.e. is the second chronological occurrence).
+        offset_difference = new_time.utc_offset - utc_offset
+        if offset_difference.positive? && (new_time2 = new_time + offset_difference).utc_offset == utc_offset
+          new_time2
+        else
+          new_time
+        end
+      elsif zone
+        ::Time.local(new_sec, new_min, new_hour, new_day, new_month, new_year, nil, nil, isdst, nil)
+      else
+        ::Time.new(new_year, new_month, new_day, new_hour, new_min, new_sec, utc_offset)
+      end
     end
 
     private def iterate_endless(start, by:)
@@ -15,7 +114,7 @@ module TimeIterator
         time = start
         loop do
           block << time
-          time += by
+          time = advance(time, by: by)
         end
       end
     end
@@ -25,7 +124,7 @@ module TimeIterator
         time = start
         while time <= to
           block << time
-          time += by
+          time = advance(time, by: by)
         end
       end
     end

--- a/spec/time_iterator_spec.rb
+++ b/spec/time_iterator_spec.rb
@@ -4,20 +4,20 @@ RSpec.describe TimeIterator do
   describe '.iterate' do
     it 'uses an Enumerator' do
       expect(
-        described_class.iterate(time, by: ActiveSupport::Duration.days(1))
+        described_class.iterate(time, by: {days: 1})
       ).to be_a(Enumerator)
     end
 
     it 'raises on an invalid `by`' do
       expect {
         described_class.iterate(time, by: :colors)
-      }.to raise_error(ArgumentError)
+      }.to raise_error(ArgumentError, /`by` must be a Hash/i)
     end
 
-    it "iterates" do
+    it "iterates Times" do
       expect(
         described_class.iterate(
-          Time.gm(2000, 1, 1), by: ActiveSupport::Duration.days(3)
+          Time.gm(2000, 1, 1), by: {days: 3}
         ).take(3)
       ).to eq [
         Time.gm(2000, 1, 1),
@@ -26,11 +26,47 @@ RSpec.describe TimeIterator do
       ]
     end
 
+    it "iterates by multiple parts" do
+      expect(
+        described_class.iterate(
+          Time.gm(2000, 1, 1), by: {days: 3, hours: 2}
+        ).take(3)
+      ).to eq [
+        Time.gm(2000, 1, 1, 0),
+        Time.gm(2000, 1, 4, 2),
+        Time.gm(2000, 1, 7, 4)
+      ]
+    end
+
+    it "iterates Dates" do
+      require 'date'
+
+      expect(
+        described_class.iterate(
+          Date.new(2000, 1, 1), by: {days: 3}
+        ).take(3)
+      ).to eq [
+        Date.new(2000, 1, 1),
+        Date.new(2000, 1, 4),
+        Date.new(2000, 1, 7)
+      ]
+    end
+
+    it "raises when iterating a Date by time part" do
+      require 'date'
+
+      expect {
+        described_class.iterate(
+          Date.new(2000, 1, 1), by: {seconds: 10}
+        )
+      }.to raise_error(ArgumentError, /cannot iterate Date by \[:seconds\]/i)
+    end
+
     it "stops before `to`" do
       expect(
         described_class.iterate(
           Time.gm(2000, 1, 1),
-          by: ActiveSupport::Duration.days(3),
+          by: {days: 3},
           to: Time.gm(2000, 1, 12)
         ).to_a
       ).to eq [
@@ -45,7 +81,7 @@ RSpec.describe TimeIterator do
       expect(
         described_class.iterate(
           Time.gm(2000, 1, 1),
-          by: ActiveSupport::Duration.days(3),
+          by: {days: 3},
           to: Time.gm(2000, 1, 10)
         ).to_a
       ).to eq [
@@ -58,7 +94,7 @@ RSpec.describe TimeIterator do
 
     it 'does not alter the original time' do
       orig = time.clone
-      described_class.iterate(time, by: ActiveSupport::Duration.weeks(2)).take(5)
+      described_class.iterate(time, by: {weeks: 2}).take(5)
       expect( time ).to eq orig
     end
   end

--- a/time_iterator.gemspec
+++ b/time_iterator.gemspec
@@ -27,6 +27,4 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.metadata['rubygems_mfa_required'] = 'true'
-
-  spec.add_dependency "activesupport", ">= 6"
 end


### PR DESCRIPTION
In the process of adding Date support, I realized I can eliminate the dependency on ActiveSupport fairly easily. Small bits of ActiveSupport have been copied in and modified as little as possible to ease future updates.

DateTimes were tried, but they introduced complications. They lack nsec and they're technically Dates. They're deprecated. We'll accept a patch if one is given.